### PR TITLE
Fix zstd dockerfs build for ONIE and for non-amd64

### DIFF
--- a/files/initramfs-tools/pzstd
+++ b/files/initramfs-tools/pzstd
@@ -13,6 +13,4 @@ esac
 . /usr/share/initramfs-tools/hook-functions
 # Include pzstd binary
 copy_exec /usr/bin/pzstd /usr/bin
-# Include any necessary libraries
-copy_exec /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu
 exit 0

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -57,6 +57,8 @@ else
     install_env="build"
 fi
 
+BUILD_REDUCE_IMAGE_SIZE=%%BUILD_REDUCE_IMAGE_SIZE%%
+
 cd $(dirname $0)
 if [ -r ./machine.conf ]; then
     read_conf_file "./machine.conf"
@@ -230,7 +232,7 @@ else
         TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
     fi
     mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
-    unzip -op $INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    unzip -op $INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar -x $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
 mkdir -p $demo_mnt/$image_dir/platform

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -102,6 +102,7 @@ sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \
        -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \
        -e "s@%%OUTPUT_RAW_IMAGE%%@$output_raw_image@" \
+       -e "s@%%BUILD_REDUCE_IMAGE_SIZE%%@$build_reduce_image_size@" \
     $tmp_installdir/install.sh || clean_up 1
 echo -n "."
 cp -r $onie_installer_payload $tmp_installdir || clean_up 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

For non-amd64, remove the explicit reference to the x86_64-linux-gnu folder. Instead, let `copy_exec` determine what libraries to copy into initramfs.

For ONIE, propagate the `BUILD_REDUCE_IMAGE_SIZE` environment variable into `install.sh`. By setting it there, the right value for `FILESYSTEM_DOCKERFS` will get set in `onie-image.conf`.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

